### PR TITLE
package.json compatible with Angular 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "angular2-popover"
   ],
   "peerDependencies": {
-    "@angular/core": "^2.0.0"
+    "@angular/core": "^2.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@angular/common": "^2.4.3",


### PR DESCRIPTION
I would like to update my app to angular 4, which is backwards compatible with angular 2. Currently I cannot update by I get this error message:

npm WARN ngx-popover@0.0.16 requires a peer of @angular/core@^2.0.0 but none was installed.

This can be fixed by changing peerDependencies to "^2.0.0 || ^4.0.0"

It would be great if you could accept this pull request so that I can update my app whilst still using ngx-popover.